### PR TITLE
Fix #2: Duplicate cron task overwrite: second schedule overwrites first

### DIFF
--- a/runner/Register-Schedules.ps1
+++ b/runner/Register-Schedules.ps1
@@ -107,11 +107,25 @@ $schedules = Get-Content -Path $schedulesFile -Raw | ConvertFrom-Json -AsHashtab
 $invokeScript = Join-Path $PSScriptRoot "Invoke-AgentJob.ps1"
 $registered = @()
 
+# Track occurrence count per agent+job key to handle duplicate cron entries
+$taskNameCount = @{}
+
 foreach ($entry in $schedules["schedules"]) {
     $agentName = $entry["agent"]
     $jobName = $entry["job"]
     $cron = $entry["cron"]
-    $taskName = "VirtualOffice-$agentName-$jobName"
+    $baseKey = "$agentName|$jobName"
+    if (-not $taskNameCount.ContainsKey($baseKey)) {
+        $taskNameCount[$baseKey] = 1
+    } else {
+        $taskNameCount[$baseKey]++
+    }
+    $occurrence = $taskNameCount[$baseKey]
+    if ($occurrence -eq 1) {
+        $taskName = "VirtualOffice-$agentName-$jobName"
+    } else {
+        $taskName = "VirtualOffice-$agentName-$jobName-$occurrence"
+    }
 
     Write-Host "Processing: $taskName (cron: $cron)"
 

--- a/tests/Test-ScheduleRegistration.ps1
+++ b/tests/Test-ScheduleRegistration.ps1
@@ -63,6 +63,29 @@ function Get-TaskName {
     return "VirtualOffice-$Agent-$Job"
 }
 
+# Helper: generate deduplicated task names from a list of schedule entries
+# Mirrors the logic in Register-Schedules.ps1
+function Get-DedupedTaskNames {
+    param([array]$Entries)
+    $taskNameCount = @{}
+    $result = @()
+    foreach ($e in $Entries) {
+        $baseKey = "$($e.agent)|$($e.job)"
+        if (-not $taskNameCount.ContainsKey($baseKey)) {
+            $taskNameCount[$baseKey] = 1
+        } else {
+            $taskNameCount[$baseKey]++
+        }
+        $occurrence = $taskNameCount[$baseKey]
+        if ($occurrence -eq 1) {
+            $result += "VirtualOffice-$($e.agent)-$($e.job)"
+        } else {
+            $result += "VirtualOffice-$($e.agent)-$($e.job)-$occurrence"
+        }
+    }
+    return $result
+}
+
 # ========================================
 # TC18: Parses schedules.json correctly
 # ========================================
@@ -113,6 +136,27 @@ Assert-True ($taskName3 -eq "VirtualOffice-a-b") "Task name: minimal input"
 
 # Verify the pattern prefix
 Assert-True ($taskName1.StartsWith("VirtualOffice-")) "Task name starts with VirtualOffice- prefix"
+
+# ========================================
+# TC19b: Duplicate agent+job entries get unique task names
+# ========================================
+Write-Host "`nTC19b: Duplicate cron entries get unique task names" -ForegroundColor Cyan
+
+$duplicateEntries = @(
+    @{ agent = "scrum-master"; job = "dry-run-ado-status-update"; cron = "0 9 * * *" }
+    @{ agent = "scrum-master"; job = "dry-run-ado-status-update"; cron = "0 21 * * *" }
+    @{ agent = "bug-killer";   job = "scan-and-fix";              cron = "0 10 * * *" }
+    @{ agent = "bug-killer";   job = "scan-and-fix";              cron = "0 22 * * *" }
+    @{ agent = "scrum-master"; job = "sprint-progress";           cron = "0 7 * * 1-5" }
+)
+$names = Get-DedupedTaskNames -Entries $duplicateEntries
+
+Assert-True ($names[0] -eq "VirtualOffice-scrum-master-dry-run-ado-status-update") "First occurrence keeps base task name"
+Assert-True ($names[1] -eq "VirtualOffice-scrum-master-dry-run-ado-status-update-2") "Second occurrence gets -2 suffix"
+Assert-True ($names[2] -eq "VirtualOffice-bug-killer-scan-and-fix") "First occurrence (different agent+job) keeps base task name"
+Assert-True ($names[3] -eq "VirtualOffice-bug-killer-scan-and-fix-2") "Second occurrence gets -2 suffix"
+Assert-True ($names[4] -eq "VirtualOffice-scrum-master-sprint-progress") "Unique entry keeps base task name"
+Assert-True (($names | Sort-Object -Unique).Count -eq $names.Count) "All generated task names are unique"
 
 # ========================================
 # TC20: Invalid cron expression handled gracefully


### PR DESCRIPTION
Closes #2

## Root Cause

`Register-Schedules.ps1` generated task names using only the agent+job combination (e.g. `VirtualOffice-emailer-scan`). When `schedules.json` had multiple entries with the same agent+job but different cron schedules, each iteration produced the same task name. The second `Register-ScheduledTask` call silently overwrote the first, leaving only the last-registered schedule active.

## Fix

Added a `$taskNameCount` hashtable to track how many times each agent+job combination has been seen. The first occurrence keeps the original name (`VirtualOffice-{agent}-{job}`). Subsequent occurrences append a numeric suffix (`VirtualOffice-{agent}-{job}-2`, `-3`, etc.), ensuring every schedule entry gets a unique task name.

## What Changed

- `runner/Register-Schedules.ps1`: Added occurrence tracking with `$taskNameCount` (lines 110-128). Task name now incorporates occurrence index for duplicate agent+job pairs.

## Validation

- Manually verified with two emailer schedule entries (10am + 10pm): both tasks now register with distinct names.
- Existing single-entry configs are unaffected — the first occurrence still uses the base name without any suffix.