### PR TITLE
Fix #3: Add EndBoundary to one-off task trigger

### DIFF
--- a/runner/Register-OneOff.ps1
+++ b/runner/Register-OneOff.ps1
@@ -42,6 +42,7 @@ $actionArgs = "-NoProfile -ExecutionPolicy Bypass -File `"$invokeScript`" -Agent
 $action = New-ScheduledTaskAction -Execute "pwsh" -Argument $actionArgs -WorkingDirectory $PROJECT_ROOT
 
 $trigger = New-ScheduledTaskTrigger -Once -At $fireTime
+$trigger.EndBoundary = $fireTime.AddMinutes(5).ToString("o")
 $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -DeleteExpiredTaskAfter (New-TimeSpan -Minutes 30)
 
 Register-ScheduledTask -TaskName $taskName -Action $action -Trigger $trigger -Settings $settings -Description "Virtual Office one-off: $Agent / $Job" | Out-Null


### PR DESCRIPTION
## Summary
- `Register-OneOff.ps1` failed with `The task XML is missing a required element or attribute: EndBoundary` because `-DeleteExpiredTaskAfter` requires the trigger to have an `EndBoundary`
- Sets `EndBoundary` to `fireTime + 5 minutes` in round-trip ISO format (`"o"`) so Task Scheduler knows when the task expires

Closes #3

## Test plan
- [x] Verified `Register-OneOff.ps1 -Agent emailer -Job scan-all-mailboxes -DelayMinutes 0` succeeds
- [x] All 57 schedule registration tests pass
- [x] No regressions in other test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)