### PR TITLE
Fix #31, #32: clear lock immediately when PID is dead

### DIFF
--- a/runner/Invoke-AgentJob.ps1
+++ b/runner/Invoke-AgentJob.ps1
@@ -377,28 +377,49 @@ if (Test-Path $lockFile) {
     $lockContent = Get-Content -Path $lockFile -Raw -ErrorAction SilentlyContinue
     $lockAge = $null
     $lockedByJob = "unknown"
+    $lockPidAlive = $true
+    $lockPid = $null
     try {
         $parsed = $lockContent.Trim() | ConvertFrom-Json
         $lockTime = [DateTime]::Parse($parsed.ts)
         $lockAge = (Get-Date) - $lockTime
         $lockedByJob = $parsed.job
+        if ($null -ne $parsed.PSObject.Properties['pid']) {
+            $lockPid = [int]$parsed.pid
+            $proc = Get-Process -Id $lockPid -ErrorAction SilentlyContinue
+            $lockPidAlive = ($null -ne $proc)
+        }
     } catch {
         $lockAge = [TimeSpan]::FromMinutes($staleLockTimeout + 1)
     }
 
-    if ($lockAge -and $lockAge.TotalMinutes -gt $staleLockTimeout) {
-        # Stale lock -- force clear
+    $clearLock = $false
+    $clearReason = ""
+    if (-not $lockPidAlive) {
+        # PID is dead -- process crashed without cleanup, clear immediately
+        $clearLock = $true
+        $clearReason = "dead_pid"
+    } elseif ($lockAge -and $lockAge.TotalMinutes -gt $staleLockTimeout) {
+        $clearLock = $true
+        $clearReason = "timeout"
+    }
+
+    if ($clearLock) {
         Remove-Item -Path $lockFile -Force
-        Write-Event -AgentName $Agent -JobName $Job -Event "stale_lock_cleared" -Details @{
+        $eventDetails = @{
             locked_by_job = $lockedByJob
             lock_age_minutes = [math]::Round($lockAge.TotalMinutes)
             timeout_minutes = $staleLockTimeout
+            clear_reason = $clearReason
         }
-        Write-AuditEntry -Action "stale_lock_cleared" -AgentName $Agent -JobName $Job -RunId "N/A" -Details @{
-            locked_by_job = $lockedByJob
-            lock_age_minutes = [math]::Round($lockAge.TotalMinutes)
+        if ($null -ne $lockPid) { $eventDetails["dead_pid"] = $lockPid }
+        Write-Event -AgentName $Agent -JobName $Job -Event "stale_lock_cleared" -Details $eventDetails
+        Write-AuditEntry -Action "stale_lock_cleared" -AgentName $Agent -JobName $Job -RunId "N/A" -Details $eventDetails
+        if ($clearReason -eq "dead_pid") {
+            Write-Host "Dead-process lock cleared for '$Agent' (PID $lockPid dead, was '$lockedByJob', age: $([math]::Round($lockAge.TotalMinutes))m)."
+        } else {
+            Write-Host "Stale lock cleared for '$Agent' (was held by '$lockedByJob', age: $([math]::Round($lockAge.TotalMinutes))m, timeout: ${staleLockTimeout}m)."
         }
-        Write-Host "Stale lock cleared for '$Agent' (was held by '$lockedByJob', age: $([math]::Round($lockAge.TotalMinutes))m, timeout: ${staleLockTimeout}m)."
     } else {
         # Agent is busy -- queue this job
         $depth = Get-QueueDepth -QueueFile $queueFile


### PR DESCRIPTION
## Summary
- Lock acquisition now checks if the lock's PID is alive before waiting for the stale lock timeout
- If the PID is dead (process crashed/OOM), the lock is cleared immediately with `clear_reason: dead_pid`
- Previously, a crashed process would block new jobs for 20-120+ minutes until the timeout expired

Closes #31
Closes #32

## Test plan
- [ ] Verify syntax check passes (`[scriptblock]::Create(...)`)
- [ ] Manual test: create a lock file with a dead PID, run a job, confirm immediate clearance
- [ ] Verify audit log records `dead_pid` clear reason

Generated with [Claude Code](https://claude.com/claude-code)