### PR TITLE
Fix #36: resolve wish-list path via constants.ps1 instead of hardcoded Q: drive

### DIFF
--- a/runner/Start-Wish.ps1
+++ b/runner/Start-Wish.ps1
@@ -1,9 +1,12 @@
-param(
+﻿param(
     [string]$Id,
     [switch]$List
 )
 
-$wishFile = "Q:\src\personal_projects\virtual-office\state\wish-list.json"
+# Resolve paths via constants so this script works on any machine regardless of drive letter
+. (Join-Path $PSScriptRoot "constants.ps1")
+
+$wishFile = Join-Path $STATE_DIR "wish-list.json"
 
 if (-not (Test-Path $wishFile)) {
     Write-Error "Wish list not found at $wishFile"
@@ -58,7 +61,7 @@ Next Steps:
 $nextSteps
 Notes: $($wish.notes)
 
-Wish list file: Q:/src/personal_projects/virtual-office/state/wish-list.json
+Wish list file: $($wishFile -replace '\\', '/')
 Wish ID: $($wish.id)
 
 When we make progress, update the wish-list.json with new status and next steps.


### PR DESCRIPTION
Closes #36

## Root cause

`Start-Wish.ps1` line 6 hardcoded `Q:\src\personal_projects\virtual-office\state\wish-list.json`.
On any machine where the repo is not on the Q: drive (e.g. AI0003 at `C:\src\jqxcode\virtual-office`),
the script fails immediately with "Wish list not found."

The context string at line 61 also hardcoded the same Q: path, which would pass incorrect path
information to the Claude session started by the script.

## Fix

- Source `constants.ps1` (already present in the same directory) to get `$STATE_DIR`
- Replace the hardcoded path with `Join-Path $STATE_DIR "wish-list.json"`
- Replace the hardcoded context string path with `$($wishFile -replace '\', '/')`

This is the same pattern used by all other runner scripts (`Invoke-AgentJob.ps1`, `Get-AgentStatus.ps1`, etc.).

## What is NOT in this PR

The larger feature requests in issue #36 (cross-machine merge recipe, dreamer ingest operation,
conflict tolerance) are intentionally out of scope. The issue itself identifies the hardcoded path
as "the only blocker that prevents any of these from working from AI0003" -- fixing it unblocks
the other work without introducing complexity.

## Validation

- Read the updated file and verified `constants.ps1` is sourced before `$STATE_DIR` is used
- Verified `constants.ps1` defines `$STATE_DIR = Join-Path $PROJECT_ROOT "state"` using `$PSScriptRoot`
- Checked no other runner scripts have wish-list hardcoded paths (dreamer.json uses `${REPO_PERSONAL}` template, which is correct)
- No existing tests for Start-Wish.ps1 to update

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>