### PR TITLE
Fix #41: block az devops login in headless agent context

### DIFF
--- a/config/jobs/pHangScout.json
+++ b/config/jobs/pHangScout.json
@@ -22,7 +22,7 @@
           },
           "interactive-auth-hang": {
             "killThresholdMinutes": 5,
-            "reason": "Bash subprocess is running an interactive auth command (az login --use-device-code or similar device code / browser OAuth flow). These commands require a human at a browser and will NEVER complete in a headless agent context. Fast-kill at 5 min -- no grace period needed."
+            "reason": "Bash subprocess is running an interactive auth command (az login --use-device-code, az devops login, or similar interactive auth flow). These commands require human input and will NEVER complete in a headless agent context. Fast-kill at 5 min -- no grace period needed."
           }
         },
         "perAgent": {


### PR DESCRIPTION
## Summary
- Add `az devops login` to the PreToolUse `block-dangerous-commands.sh` hook alongside the existing `az login --use-device-code` block, preventing interactive auth commands that hang forever in headless agent context
- Update hang scout `interactive-auth-hang` classification reason in `pHangScout.json` to explicitly mention `az devops login`
- Refine the hook to check only the first line of the command to avoid false positives when the phrase appears in heredoc content (e.g., commit messages)

## Test plan
- [ ] Verify `az devops login` is blocked by the hook with appropriate error message
- [ ] Verify `az login --use-device-code` still blocked
- [ ] Verify normal `az devops` subcommands (e.g., `az devops project list`) are NOT blocked
- [ ] Verify commit messages mentioning "az devops login" are not false-positive blocked

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)