### PR TITLE
Fix #69: disambiguate the two DESIGN.md files in report-rules Rule #0

### DIFF
--- a/config/report-rules.md
+++ b/config/report-rules.md
@@ -4,7 +4,13 @@ All VO agent jobs MUST follow these rules when generating reports. Read this fil
 
 ## 0. Design System (HIGHEST PRIORITY)
 
-All HTML reports MUST follow `${SRC_ROOT}/DESIGN.md` (Stripe-inspired design system). Use `--stripe-*` CSS custom properties exclusively. NEVER hardcode hex colors. NEVER use the old `--vo-*` dark theme variables. If a template still uses `--vo-*` tokens, you MUST convert them to `--stripe-*` equivalents from DESIGN.md before generating the report.
+All HTML reports MUST follow the report design system at `${SRC_ROOT}/DESIGN.md` (titled "Design System Inspired by Stripe"). Use `--stripe-*` CSS custom properties exclusively. NEVER hardcode hex colors. NEVER use the old `--vo-*` dark theme variables. If a template still uses `--vo-*` tokens, you MUST convert them to `--stripe-*` equivalents from `${SRC_ROOT}/DESIGN.md` before generating the report.
+
+IMPORTANT -- do not confuse the two DESIGN.md files:
+- `${SRC_ROOT}/DESIGN.md` (repo root, "Design System Inspired by Stripe") -- the report design system. This is the ONLY DESIGN.md this rule refers to. It defines the `--stripe-*` tokens.
+- `virtual-office/DESIGN.md` ("Virtual Office -- Design Document") -- the product/UX design document for the VO app and dashboard. It uses the older Linear `--vo-*` theme and is NOT the report design system. Do NOT source report CSS tokens from this file.
+
+If you find `${SRC_ROOT}/DESIGN.md` uses `--vo-*` (or does not define `--stripe-*`), do NOT fabricate tokens or silently fall back to the product DESIGN.md -- flag the mismatch instead.
 
 ## 1. Fixed Template
 


### PR DESCRIPTION
Closes #69

## Root cause

Issue #69 reported that `config/report-rules.md` Rule #0 (which mandates a Stripe design system with `--stripe-*` tokens) contradicts "DESIGN.md" (claimed to be a Linear `--vo-*` dark theme). Verification on the host shows the real cause is a **filename collision between two different DESIGN.md files**, not a contradiction inside a single file:

- `${SRC_ROOT}/DESIGN.md` (repo root) -- titled "Design System Inspired by Stripe". 49 `--stripe-*` hits, 0 `--vo-*`. This is the report design system Rule #0 actually points to. Rule #0 is consistent with it.
- `virtual-office/DESIGN.md` -- titled "Virtual Office -- Design Document". 63 `--vo-*` hits, 0 `--stripe-*`. This is the product/UX design document for the VO app, NOT the report design system.

The two files are unrelated (`Get-FileHash` differs). Issue #69's author read the repo-local product DESIGN.md and assumed it was the file Rule #0 references, producing a false-positive contradiction report.

## What the fix does

Clarifies Rule #0 so the reference is unambiguous:
- Explicitly names the report design system file (`${SRC_ROOT}/DESIGN.md`, "Design System Inspired by Stripe") as the ONLY DESIGN.md this rule refers to.
- Documents the second file (`virtual-office/DESIGN.md`, the product design document, `--vo-*`) and states it must NOT be used to source report CSS tokens.
- Adds a no-fabrication guard: if the report DESIGN.md ever lacks `--stripe-*`, flag the mismatch rather than falling back to the product doc.

This is a documentation-only change (7 insertions, 1 deletion in `config/report-rules.md`). No template, runner, or CSS behavior changes.

## Validation

- Verified `${SRC_ROOT}/DESIGN.md` = Stripe (49 `--stripe-*`, 0 `--vo-*`) and `virtual-office/DESIGN.md` = product doc (63 `--vo-*`, 0 `--stripe-*`); hashes differ.
- Confirmed Rule #0 already resolves to the Stripe file and is internally consistent; only the ambiguity needed fixing.
- Change is ASCII-only per repo conventions; no runner/PS1 files touched, so no test suite is affected.
